### PR TITLE
add IMU sensor

### DIFF
--- a/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base.xacro
+++ b/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base.xacro
@@ -151,9 +151,9 @@
       update_rate="2.0"/>
 
     <xacro:include filename="$(find glider_hybrid_whoi_description)/urdf/glider_hybrid_whoi_sensors.xacro"/>
-<!--
     <xacro:include filename="$(find glider_hybrid_whoi_description)/urdf/uw_gps_plugin.xacro"/>
--->
+    <xacro:include filename="$(find glider_hybrid_whoi_description)/urdf/uw_imu_plugin.xacro"/>
+
   </xacro:macro>
 
 </robot>

--- a/glider_hybrid_whoi_description/urdf/uw_imu_plugin.xacro
+++ b/glider_hybrid_whoi_description/urdf/uw_imu_plugin.xacro
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!-- from https://answers.ros.org/question/328520/imu-plugin-has-strange-measurements-in-rviz/ -->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <xacro:macro name="hector_imu_macro" params="parent *origin">
+
+        <material name="imu-orange">
+            <color rgba="0.8862745098 0.56862745098 0.09019607843 1"/>
+        </material>
+
+        <joint name="${parent}_to_hector_imu" type="fixed">
+            <parent link="${parent}"/>
+            <child link="hector_imu"/>
+            <xacro:insert_block name="origin"/>
+        </joint>
+
+        <link name="hector_imu">
+            <visual>
+                <origin rpy="0 0 0" xyz="0 0 0"/>
+                <geometry>
+                    <box size="0.057 0.041 0.024"/> <!--a simple box is used with the outer dimensions for simplicity-->
+                </geometry>
+                <material name="imu-orange"/>
+            </visual>
+            <collision>
+                <origin rpy="0 0 0" xyz="0 0 0"/>
+                <geometry>
+                    <box size="0.057 0.041 0.024"/>
+                </geometry>
+            </collision>
+            <inertial>
+                <mass value="0.055"/>
+                <origin xyz="0 0 0"/>
+                <inertia ixx="1.60333333333e-05" ixy="0.0" ixz="0.0" iyy="2.80333333333e-05" iyz="0.0"
+                         izz="1.60333333333e-05"/>
+            </inertial>
+        </link>
+
+        <gazebo>
+            <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
+                <alwaysOn>true</alwaysOn>
+                <updateRate>400.0</updateRate>
+                <bodyName>hector_imu</bodyName>
+                <topicName>hector_imu</topicName>
+                <robotNamespace>sensors</robotNamespace>
+                <serviceName>hector_imu/is_calibrated</serviceName>
+                <gaussianNoise>0.00000001</gaussianNoise>
+                <xyzOffsets>0 0 0</xyzOffsets>
+                <rpyOffsets>0 0 0</rpyOffsets>
+                <frameId>world</frameId>
+            </plugin>
+        </gazebo>
+    </xacro:macro>
+
+    <xacro:hector_imu_macro parent="${namespace}/imu_link">
+      <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+    </xacro:hector_imu_macro>
+
+</robot>
+

--- a/glider_hybrid_whoi_gazebo/launch/glider_with_sensors.launch
+++ b/glider_hybrid_whoi_gazebo/launch/glider_with_sensors.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- world -->
+  <include file="$(find uuv_gazebo_worlds)/launch/ocean_waves.launch">
+  </include>
+
+  <!-- teleop -->
+  <include file="$(find glider_hybrid_whoi_gazebo)/launch/start_demo_teleop.launch">
+  </include>
+
+</launch>
+


### PR DESCRIPTION
To test GPS:

To test: type these commands in each of three command windows:

* roslaunch uuv_gazebo_worlds ocean_waves.launch
* roslaunch glider_hybrid_whoi_gazebo start_demo_teleop.launch joy_id:=0
* rostopic echo glider_hybrid_whoi/fix

Then Raise the glider to an elevation >= -0.1 meters to see topic data.

Two topics are published when elevation >= -0.1: glider_hybrid_whoi/fix and glider_hybrid_whoi/fix_velocity

Elevation is hardcoded in file glider_hybrid_whoi/hybrid_glider_gazebo_plugins/hybrid_glider_gazebo_ros_plugins/src/UnderwaterGPSROSPlugin.cc. If desired, we can change this to 0.0 or make it selectable.

To test IMU:

* roslaunch uuv_gazebo_worlds ocean_waves.launch
* roslaunch glider_hybrid_whoi_gazebo start_demo_teleop.launch joy_id:=0
* rostopic echo sensors/hector_imu

IMU services are also available, type `rosservice list | grep hector_imu`.


**Note: we still need to calibrate these sensors.**