### PR TITLE
Add DVL sensor

### DIFF
--- a/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_sensors_kinematics.xacro
+++ b/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_sensors_kinematics.xacro
@@ -22,7 +22,7 @@
       inertial_reference_frame="${inertial_reference_frame}" />
 
     <!-- DVL sensor -->
-    <xacro:dvl_plugin_macro
+    <!-- <xacro:dvl_plugin_macro
       namespace="${namespace}"
       suffix=""
       parent_link="${namespace}/base_link"
@@ -33,7 +33,13 @@
       update_rate="7"
       reference_frame="world">
       <origin xyz="0.0 0.0 -0.0825" rpy="0 ${0.5*pi} 0" />
-    </xacro:dvl_plugin_macro>
+    </xacro:dvl_plugin_macro> -->
+
+  <xacro:include filename="$(find nps_uw_sensors_gazebo)/urdf/whoi_teledyne_whn.xacro"/>
+  <xacro:teledyne_whn_macro
+    name="dvl" namespace="dvl" xyz="0 0 0"
+    dvl_topic="dvl" ranges_topic="ranges"
+    robot_link="${namespace}/base_link" joint_xyz="0 0 0"/>
 
     <xacro:switchable_battery_consumer_macro
       link_name="${namespace}/dvl_link"

--- a/glider_hybrid_whoi_gazebo/launch/start_demo_kinematics.launch
+++ b/glider_hybrid_whoi_gazebo/launch/start_demo_kinematics.launch
@@ -8,6 +8,7 @@
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
       <arg name="world_name" value="$(find glider_hybrid_whoi_gazebo)/worlds/seafloor_underwater.world"/>
+      <arg name="extra_gazebo_args" value="-s libdsros_sensors.so"/>
       <arg name="paused" value="$(arg paused)"/>
       <arg name="use_sim_time" value="true"/>
       <arg name="gui" value="$(arg gui)"/>


### PR DESCRIPTION
### DVL sensor of `nps_uw_sensors_gazebo` is added.
Sensor specifications are defined at the `nps_uw_sensors_gazebo` repository.
#### Edited block to add the DVL sensor
https://github.com/Field-Robotics-Lab/glider_hybrid_whoi/blob/4e6433e445da9a9dadd4318a05b1437553307051/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_sensors_kinematics.xacro#L38-L42
#### Sensor specification
https://github.com/Field-Robotics-Lab/nps_uw_sensors_gazebo/blob/c840db6946c2a839a5153595d2aef2d300ad64b0/models/whoi_teledyne_whn/model.sdf#L20-L49
```XML
      <sensor name="dvl_sensor" type="dsros_dvl">
        <always_on>1</always_on>
        <update_rate>7.0</update_rate>
        <plugin name="dvl_sensor_controller" filename="libdsros_ros_dvl.so">
          <robotNamespace>dvl</robotNamespace>
          <topicName>dvl</topicName>
          <rangesTopicName>ranges</rangesTopicName>
          <frameName>dvl_base_link</frameName>
          <pointcloudFrame>dvl_base_link</pointcloudFrame>
          <updateRateHZ>7.0</updateRateHZ>
          <gaussianNoiseBeamVel>0.005</gaussianNoiseBeamVel>
          <gaussianNoiseBeamWtrVel>0.0075</gaussianNoiseBeamWtrVel>
          <gaussianNoiseBeamRange>0.1</gaussianNoiseBeamRange>
          <minRange>0.7</minRange>
          <maxRange>90.0</maxRange>
          <maxRangeDiff>10</maxRangeDiff>
          <beamAngleDeg>30.0</beamAngleDeg>
          <beamWidthDeg>4.0</beamWidthDeg>
          <beamAzimuthDeg1>-135</beamAzimuthDeg1>
          <beamAzimuthDeg2>135</beamAzimuthDeg2>
          <beamAzimuthDeg3>45</beamAzimuthDeg3>
          <beamAzimuthDeg4>-45</beamAzimuthDeg4>
          <enableWaterTrack>1</enableWaterTrack>
          <waterTrackBins>10</waterTrackBins>
          <currentProfileCoordMode>0</currentProfileCoordMode>
          <pos_z_down>false</pos_z_down>
          <collide_bitmask>0x0001</collide_bitmask>
        </plugin>
        <pose>0 0 0 0 0 0</pose>
      </sensor>
```
#### Topics
- `/dvl/dvl/state` (std_msgs/Bool): should be true as long as the DVL is active (can be activated and deactivated with the /dvl/dvl/change_state service).
- `/dvl/dvl` (uuv_sensor_ros_plugins_msgs/DVL): provides the current DVL-derived linear velocities (relative to the dvl_base_link, which is oriented forward-left-up) and covariance, perceived altitude above the bottom (computed as the average of the 4 individual sonar ranges), and the ranges and other information for the 4 individual DVL sonar beams.
- `/dvl/dvl_twist` (geometry_msgs/TwistWithCovarianceStamped): provides the current DVL-derived linear velocities
- `/dvl/dvl_sonar0, /dvl/dvl_sonar1, /dvl/dvl_sonar2, and /dvl/dvl_sonar3` (sensor_msgs/Range): Range and other information for each individual DVL sonar

#### Tutorials for the sensor and water tracking features including seabed gradient
https://github.com/Field-Robotics-Lab/dave/wiki/whn_dvl_examples
https://github.com/Field-Robotics-Lab/dave/wiki/DVL-Water-Tracking
https://github.com/Field-Robotics-Lab/dave/wiki/DVL-Seabed-Gradient

#### How to test
````bash
roslaunch glider_hybrid_whoi_gazebo start_demo_kinematics.launch
````