### PR TITLE
Add Altimeter

### DIFF
--- a/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_sensors_kinematics.xacro
+++ b/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_sensors_kinematics.xacro
@@ -26,33 +26,19 @@
       namespace="${namespace}"
       suffix=""
       parent_link="${namespace}/base_link"
-      topic="dvl"
+      topic="altimeter"
       scale="0.62"
       noise_sigma="0"
       noise_amplitude="0"
-      update_rate="7"
+      update_rate="0.25"
       reference_frame="world">
-      <origin xyz="0.0 0.0 -0.0825" rpy="0 ${0.5*pi} 0" />
+      <origin xyz="0.0 0.0 -0.0825" rpy="0 ${0.355556*pi} 0" />
     </xacro:dvl_plugin_macro>
-
-    <xacro:switchable_battery_consumer_macro
-      link_name="${namespace}/dvl_link"
-      battery_link="${namespace}/battery_link"
-      battery_name="${namespace}/battery"
-      power_load="25"
-      topic="${namespace}/dvl/state"/>
 
     <!-- IMU  -->
     <xacro:default_imu namespace="${namespace}" parent_link="${namespace}/base_link">
       <origin xyz="0 0 0" rpy="0 0 0"/>
     </xacro:default_imu>
-
-    <xacro:switchable_battery_consumer_macro
-      link_name="${namespace}/imu_link"
-      battery_link="${namespace}/battery_link"
-      battery_name="${namespace}/battery"
-      power_load="20"
-      topic="${namespace}/imu/state"/>
 
     <!-- Mount a camera -->
     <xacro:regular_camera_plugin_macro
@@ -74,11 +60,11 @@
     <!-- Mount a GPS. -->
     <xacro:default_gps namespace="${namespace}" parent_link="${namespace}/base_link" />
 
-    <xacro:switchable_battery_consumer_macro
+    <!-- <xacro:switchable_battery_consumer_macro
       link_name="${namespace}/gps_link"
       battery_link="${namespace}/battery_link"
       battery_name="${namespace}/battery"
       power_load="5"
-      topic=""/>
+      topic=""/> -->
 
 </robot>


### PR DESCRIPTION
An altimeter is added with a pre-Dave project (UUV simulator's) DVL sensor. The DVL sensor has simpler specifications available than the Dave project's one. It has some link names with the phrase dvl but added to act as an altimeter with the orientation we need.

#### Specifications
- The altimeter is pitched 26 degrees above horizontal (if the glider is descending at a 26 degree angle, the altimeter is pointed straight down)
- Update Rate is 4 seconds (0.25 Hz)

#### Topic lists
`/glider_hybrid_whoi/altimeter`
`/glider_hybrid_whoi/altimeter/state`
`/glider_hybrid_whoi/altimeter_sonar0`
`/glider_hybrid_whoi/altimeter_sonar1`
`/glider_hybrid_whoi/altimeter_sonar2`
`/glider_hybrid_whoi/altimeter_sonar3`
`/glider_hybrid_whoi/altimeter_twist`

#### How to test
````bash
roslaunch glider_hybrid_whoi_gazebo start_demo_kinematics.launch
````