### PR TITLE
Added beams and scaling factor for WHOI DVL

### DIFF
--- a/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_sensors_kinematics.xacro
+++ b/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_sensors_kinematics.xacro
@@ -35,11 +35,11 @@
       <origin xyz="0.0 0.0 -0.0825" rpy="0 ${0.5*pi} 0" />
     </xacro:dvl_plugin_macro> -->
 
-  <xacro:include filename="$(find nps_uw_sensors_gazebo)/urdf/whoi_teledyne_whn.xacro"/>
+  <xacro:include filename="$(find nps_uw_sensors_gazebo)/urdf/whoi_teledyne_whn_beams.xacro"/>
   <xacro:teledyne_whn_macro
     name="dvl" namespace="dvl" xyz="0 0 0"
     dvl_topic="dvl" ranges_topic="ranges"
-    robot_link="${namespace}/base_link" joint_xyz="0 0 0"/>
+    robot_link="${namespace}/base_link" joint_xyz="0 0 0" scale="0.25 0.25 0.25" ray_visual="1"/>
 
     <!-- IMU  -->
     <xacro:default_imu namespace="${namespace}" parent_link="${namespace}/base_link">

--- a/glider_hybrid_whoi_gazebo/launch/start_demo_kinematics.launch
+++ b/glider_hybrid_whoi_gazebo/launch/start_demo_kinematics.launch
@@ -62,8 +62,8 @@
   <arg name="joy_id" default="0"/>
 
   <!-- Vehicle's initial position -->
-  <arg name="x" default="480381.43"/>
-  <arg name="y" default="56666.85"/>
+  <arg name="x" default="4"/>
+  <arg name="y" default="4"/>
   <arg name="z" default="-93"/>
   <arg name="roll" value="0"/>
   <arg name="pitch" default="0"/>


### PR DESCRIPTION
PR solves the issue of WHOI DVL not showing emanating sensor beams and adds scaling factor to DVL to fit the glider model. Primary changes made in PR Field-Robotics-Lab/nps_uw_sensors_gazebo#49

In this branch, the `glider_hybrid_whoi_sensors_kinematics.xacro` has been modified to pass the `scale` and `ray_visual` parameters to `teledyne_whn_macro` in `whoi_teledyne_whn_beams.xacro`

To test, switch to `nps_uw_sensors_gazebo` branch, `dvl_scale_and_beams` and run `roslaunch glider_hybrid_whoi_gazebo start_demo_kinematics.launch`.

The DVL will not appear if there are errors during loading, but in the absence of error the following should be observed in RViz and Gazebo:

DVL scaled down to where it is not protruding out of the vehicle
![Screenshot from 2021-03-07 20-12-31](https://user-images.githubusercontent.com/8268930/110253985-f6535880-7f84-11eb-8c93-d20f61774f39.png)
Beams coming from DVL origin
![Screenshot from 2021-03-07 20-14-17](https://user-images.githubusercontent.com/8268930/110253988-fb180c80-7f84-11eb-8c22-b38040fa8c4c.png)

