### PR TITLE
Publish GPS topic only at the surface

### DIFF
--- a/direct_kinematics_ros_plugins/test/test_directKinematics.py
+++ b/direct_kinematics_ros_plugins/test/test_directKinematics.py
@@ -23,7 +23,21 @@ def command(startTime):
             command.header.stamp = rospy.Time.now()
             command.pitch_cmd_type = 1
             command.target_pitch_value = -0.01
-            command.target_pumped_volume = 0.5
+            command.target_pumped_volume = -0.5
+            command.rudder_control_mode = 1
+            command.target_heading = math.pi/2
+            command.motor_cmd_type = 1
+            command.target_motor_cmd = 0.01
+            rospy.loginfo(command)
+            pub.publish(command)
+            time.sleep(25)
+
+            print("\n----- Descend with Pitch control (Batt pos) + Buoyancy engine + Rudder control (angle)------")
+            command = UwGliderCommand()
+            command.header.stamp = rospy.Time.now()
+            command.pitch_cmd_type = 1
+            command.target_pitch_value = 0.01
+            command.target_pumped_volume = -0.5
             command.rudder_control_mode = 1
             command.target_heading = math.pi/2
             command.motor_cmd_type = 1


### PR DESCRIPTION
The hector GPS sensor plugin is modified to publish data only at the surface.

#### Quickstart for test
1. Edit starting depth of the glider to reach the surface faster for tests, e.g. -93 to -3
https://github.com/Field-Robotics-Lab/glider_hybrid_whoi/blob/b520042e8e18275bb27f58cef195de1bb06becb6/glider_hybrid_whoi_gazebo/launch/start_demo_kinematics_stratified_current.launch#L66
2. Launch
   ```
   roslaunch glider_hybrid_whoi_gazebo start_demo_kinematics_stratified_current.launch
   ```
3. Track GPS topic on another terminal window
   ```
   rostopic echo /glider_hybrid_whoi/hector_gps
   ```
3. Run the commanding script to drive the glider to the surface (edit path according to your machine)
   - The script will make the glider ascend and stay on the surface for about 12 seconds and descend again. (Assuming that the starting depth as -3)
   ```
   python glider_hybrid_whoi/direct_kinematics_ros_plugins/test/test_directKinematics.py
   ```
4. /glider_hybrid_whoi/hector_gps topic is published only when the glider is at the surface.
