### PR TITLE
Pitch/AOA based on dynamics calculation

### DIFF
--- a/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base_kinematics.xacro
+++ b/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base_kinematics.xacro
@@ -160,7 +160,7 @@
 
         <!-- Dynamics properties -->
         <use_dynamics>true</use_dynamics>
-        <hard_code_input>true</hard_code_input>
+        <hard_code_input>false</hard_code_input>
         <dynamics>
           <hull_mass>48.2</hull_mass>
           <hull_length>2.0</hull_length>

--- a/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base_kinematics.xacro
+++ b/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base_kinematics.xacro
@@ -160,7 +160,7 @@
 
         <!-- Dynamics properties -->
         <use_dynamics>true</use_dynamics>
-        <hard_code_input>false</hard_code_input>
+        <hard_code_input>true</hard_code_input>
         <dynamics>
           <hull_mass>48.2</hull_mass>
           <hull_length>2.0</hull_length>
@@ -177,11 +177,11 @@
           <center_of_gravity>0 0 0.0054</center_of_gravity>
           <linear_damping>
             0       0       0       0       0       0
-            0       0       0       0       0       0
-            0       0       -14     0       0       0
+            0       -50     0       0       0       0
+            0       0       -50     0       0       0
             0       0       0       0       0       0
             0       0       0       0       -12     0
-            0       0       0       0       0       0
+            0       0       0       0       0       -12
           </linear_damping>
         </dynamics>
       </plugin>

--- a/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base_kinematics.xacro
+++ b/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base_kinematics.xacro
@@ -157,6 +157,33 @@
         <f_thruster_power_w1>-0.020919</f_thruster_power_w1>
         <f_thruster_power_w2>1.4699</f_thruster_power_w2>
         <f_thruster_power_w3>0.97895</f_thruster_power_w3>
+
+        <!-- Dynamics properties -->
+        <use_dynamics>true</use_dynamics>
+        <hard_code_input>true</hard_code_input>
+        <dynamics>
+          <hull_mass>48.2</hull_mass>
+          <hull_length>2.0</hull_length>
+          <hull_radius>0.105</hull_radius>
+          <shifter_mass>7.8</shifter_mass>
+          <ballast_radius>0.07</ballast_radius>
+          <default_mass_position>0.4</default_mass_position>
+          <default_ballast_position>0.711</default_ballast_position>
+          <initial_mass_position>-0.018</initial_mass_position>
+          <initial_ballast_position>-0.01024</initial_ballast_position>
+          <max_mass_position>0.03</max_mass_position>
+          <max_ballast_volume>2.4e-04</max_ballast_volume>
+          <center_of_buoyancy>0 0 0</center_of_buoyancy>
+          <center_of_gravity>0 0 0.0054</center_of_gravity>
+          <linear_damping>
+            0       0       0       0       0       0
+            0       0       0       0       0       0
+            0       0       -14     0       0       0
+            0       0       0       0       0       0
+            0       0       0       0       -12     0
+            0       0       0       0       0       0
+          </linear_damping>
+        </dynamics>
       </plugin>
       <plugin name="{namespace}_dave_ocean_current_plugin" filename="libdave_ocean_current_model_plugin.so">
         <flow_velocity_topic>hydrodynamics/current_velocity/${namespace}</flow_velocity_topic>
@@ -176,7 +203,7 @@
             <noiseFreq>0.0</noiseFreq>
           </velocity_down>
         </transient_current>
-        <tide_oscillation>true</tide_oscillation>
+        <tide_oscillation>false</tide_oscillation>
       </plugin>
     </gazebo>
 

--- a/glider_hybrid_whoi_gazebo/worlds/seafloor_underwater_stratified_current.world
+++ b/glider_hybrid_whoi_gazebo/worlds/seafloor_underwater_stratified_current.world
@@ -119,9 +119,9 @@
       <transient_current>
         <topic_stratified_database>stratified_current_velocity_database</topic_stratified_database>
         <!-- Database tag can accept full path or filename for .csv within the uuv_dave/worlds folder  -->
-        <databasefilePath>transientOceanCurrentDatabase.csv</databasefilePath>
+        <!-- <databasefilePath>transientOceanCurrentDatabase.csv</databasefilePath> -->
         <!-- Absolute path in local machine -->
-        <!-- <databasefilePath>/home/glider-sim/uuv_ws/src/glider_hybrid_whoi/glider_hybrid_whoi_gazebo/worlds/transientOceanCurrentDatabase.csv</databasefilePath> -->
+        <databasefilePath>/home/woensug/uuv_ws/src/glider_hybrid_whoi/glider_hybrid_whoi_gazebo/worlds/transientOceanCurrentDatabase_zero.csv</databasefilePath>
         <!-- Absolute path in docker environment -->
         <!-- <databasefilePath>/home/ros/glider_hybrid_whoi/install/share/glider_hybrid_whoi_gazebo/worlds/transientOceanCurrentDatabase.csv</databasefilePath> -->
       </transient_current>

--- a/kinematics_ros_plugins/include/kinematics_ros_plugins/KinematicsROSPlugin.hh
+++ b/kinematics_ros_plugins/include/kinematics_ros_plugins/KinematicsROSPlugin.hh
@@ -291,10 +291,12 @@ namespace kinematics_ros
     /// \brief Last timestamp (in seconds)
     protected: double lastTime;
 
-    /// \brief Last body-fixed relative velocity (nu_R in Fossen's equations)
+    /// \brief Dynamics post/vel variables
+    protected: Eigen::Vector6d eta, eta_last, eta_dot, eta_dot_last;
+    protected: Eigen::Vector6d nu, nu_last, nu_dot, nu_dot_last;
     protected: Eigen::Vector6d lastVelRel;
-    protected: Eigen::Vector3d targetLinearVel_prev;
-    protected: Eigen::Vector3d targetAngularVel_prev;
+    // protected: Eigen::Vector3d targetLinearVel_prev;
+    // protected: Eigen::Vector3d targetAngularVel_prev;
 
     /// \brief Get parameters (read matrix form defenitions)
     protected: void GetParam(std::string _tag, std::vector<double>& _output);
@@ -470,6 +472,23 @@ inline ignition::math::Matrix3d Mat3dToGazebo(const Eigen::Matrix3d &_x)
   return ignition::math::Matrix3d(_x(0, 0), _x(0, 1), _x(0, 2),
      _x(1, 0), _x(1, 1), _x(1, 2),
      _x(2, 0), _x(2, 1), _x(2, 2));
+}
+
+inline Eigen::Matrix6d Jacobian(const double &phi,
+                                const double &theta,
+                                const double &psi)
+{
+    Eigen::Matrix6d out;
+    out << cos(psi)*cos(theta),
+    -sin(psi)*cos(phi)+cos(psi)*sin(theta)*sin(phi),
+    sin(psi)*sin(phi)+cos(psi)*cos(phi)*sin(theta), 0, 0, 0,
+    sin(psi)*cos(theta), cos(psi)*cos(phi)+sin(psi)*sin(theta)*sin(phi),
+    -cos(psi)*sin(phi)+sin(psi)*sin(theta)*cos(phi), 0, 0, 0,
+    -sin(theta), cos(theta)*sin(phi), cos(theta)*cos(phi), 0, 0, 0,
+    0, 0, 0, 1, sin(phi)*tan(theta), cos(phi)*tan(theta),
+    0, 0, 0, 0, cos(phi), -sin(phi),
+    0, 0, 0, 0, sin(phi)/cos(theta), cos(phi)/cos(theta);
+    return out;
 }
 }
 

--- a/kinematics_ros_plugins/include/kinematics_ros_plugins/KinematicsROSPlugin.hh
+++ b/kinematics_ros_plugins/include/kinematics_ros_plugins/KinematicsROSPlugin.hh
@@ -226,6 +226,108 @@ namespace kinematics_ros
     protected: double C_L;
 
     /// ============================================= ///
+    /// ===========   DYNAMICS (for pitch)   ======== ///
+    /// ============================================= ///
+    /// \brief A flag for dynamics calculations
+    private: bool dynamics;
+
+    /// \brief A flag for hardcoded input
+    private: bool hardCodeInput;
+
+    /// \brief Buoyancy pump position
+    protected: double pumpPos;
+
+    /// \brief Sliding mass position
+    protected: double massPos;
+
+    /// \brief total_mass
+    protected: double m;
+
+    /// \brief Center of gravity
+    protected: ignition::math::Vector3d cog;
+
+    /// \brief Center of buoyancy in the body frame
+    protected: ignition::math::Vector3d cob;
+
+    /// \brief ballast_radius
+    protected: double r_w;
+
+    /// \brief hull_length
+    protected: double l_h;
+
+    /// \brief hull_radius
+    protected: double r_h;
+
+    /// \brief hull_mass
+    protected: double m_h;
+
+    /// \brief shifter_mass
+    protected: double m_s;
+
+    /// \brief initial_mass_position
+    protected: double x_s_o;
+
+    /// \brief initial_ballast_position
+    protected: double x_w_o;
+
+    /// \brief max_mass_position
+    protected: double x_s_o_max;
+
+    /// \brief max_ballast_volume
+    protected: double vol_w_max;
+
+    /// \brief Added-mass matrix
+    protected: Eigen::Matrix6d Ma;
+
+    /// \brief Added-mass associated Coriolis matrix
+    protected: Eigen::Matrix6d Ca;
+
+    /// \brief Damping matrix
+    protected: Eigen::Matrix6d D;
+
+    /// \brief Linear damping matrix
+    protected: Eigen::Matrix6d DLin;
+
+    /// \brief Last timestamp (in seconds)
+    protected: double lastTime;
+
+    /// \brief Last body-fixed relative velocity (nu_R in Fossen's equations)
+    protected: Eigen::Vector6d lastVelRel;
+    protected: Eigen::Vector3d targetLinearVel_prev;
+    protected: Eigen::Vector3d targetAngularVel_prev;
+
+    /// \brief Get parameters (read matrix form defenitions)
+    protected: void GetParam(std::string _tag, std::vector<double>& _output);
+
+    /// \brief Filtered linear & angular acceleration vector in link frame.
+    /// This is used to prevent the model to become unstable given that Gazebo
+    /// only calls the update function at the beginning or at the end of a
+    /// iteration of the physics engine
+    protected: Eigen::Vector6d filteredAcc;
+
+    /// \brief Computes the added-mass Coriolis matrix Ca.
+    protected: void ComputeAddedCoriolisMatrix(const Eigen::Vector6d& _vel,
+                                             Eigen::Matrix6d &_Ma,
+                                             Eigen::Matrix6d &_Ca) const;
+
+    /// \brief Updates the damping matrix for the current velocity
+    protected: void ComputeDampingMatrix(const Eigen::Vector6d& _vel,
+                                       Eigen::Matrix6d &_D) const;
+
+    /// \brief Filter acceleration (fix due to the update structure of Gazebo)
+    protected: void ComputeAcc(Eigen::Vector6d _velRel,
+                            double _time,
+                            double _alpha = 0.3);
+
+    /// \brief Convey commands to calculate dynamics
+    protected: virtual void ConveyDynamicsCommands
+        (const frl_vehicle_msgs::UwGliderCommand::ConstPtr &_msg);
+
+    /// \brief Calculate dynamics when commands conveyed and every updates
+    protected: virtual void CalculateDynamics
+        (double _massPos, double _pumpVol, double _thrustPower);
+
+    /// ============================================= ///
     /// ===========-=== Visual Effects ======-======= ///
     /// ============================================= ///
 

--- a/kinematics_ros_plugins/src/KinematicsROSPlugin.cc
+++ b/kinematics_ros_plugins/src/KinematicsROSPlugin.cc
@@ -448,7 +448,7 @@ void KinematicsROSPlugin::ConveyDynamicsCommands(
 
     default:
       gzmsg << "WRONG PITCH COMMAND TYPE "
-          << " For dynamics only (1 : battery position) can be used"
+          << " For dynamics, only (1 : battery position) can be used"
           << std::endl;
       break;
   }
@@ -812,10 +812,12 @@ void KinematicsROSPlugin::ConveyKinematicsCommands(
   {
     case frl_vehicle_msgs::UwGliderCommand::PITCH_CMD_BATT_POS:
     {
-      this->battpos = _msg->target_pitch_value/39.3701*1000;  // [m to inch]
-      double target_pitch_rad
-                = this->f_pitch_battpos_cal_m * this->battpos + this->f_pitch_battpos_cal_b;
-      target_pitch = target_pitch_rad;
+      // Commented out : Use dynamics flag for battery position command
+      gzmsg << "USE DYNAMICS for battery position command " << std::endl;
+      // this->battpos = _msg->target_pitch_value/39.3701*1000;  // [m to inch]
+      // double target_pitch_rad
+      //           = this->f_pitch_battpos_cal_m * this->battpos + this->f_pitch_battpos_cal_b;
+      // target_pitch = target_pitch_rad;
       break;
     }
 


### PR DESCRIPTION
### Ported dynamics calculation from the [previous branch](https://github.com/Field-Robotics-Lab/glider_hybrid_whoi/tree/DirectROSKinematics_plugin) on top of current working kinematics plugin to calculate PITCH.

#### > Status of the previous branch : Unstable, only work for 3-DOF (pitch-X-Z)
Last time, the 6-DOF dynamics calculation was coded based on [Isa, 2014 Paper](https://www.sciencedirect.com/science/article/pii/S0029801814000341) modified to [EPIC-DAUG Glider dynamics Overleaf](https://www.overleaf.com/read/pqstymzccttj). **HOWEVER, it only was stable for 3-DOF** (only moving forward; only pitch-X-Z calculation). The background equations are verified at MATLAB, and 3-DOF hard input comparisons look promising. But not in Gazebo (in Gazebo, the force turms are applied as force input to the model with `this->link->AddRelativeForce(hydForce)`)

#### > Porting dynamics calculation for the pitch to Kinematics to replace flight model
This PR is an attempt to use dynamics based pitch calculation. Yaw controls are done kinematically. Something like a hybrid dynamics-kinematics method.

- For dynamics calculation,
   - Pitch command type of battery position `frl_vehicle_msgs::UwGliderCommand::PITCH_CMD_BATT_POS` should be used
   - Dynamics flag should be on https://github.com/Field-Robotics-Lab/glider_hybrid_whoi/blob/3bd43f898435947930e04a4b54a7cc23ada91950/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base_kinematics.xacro#L162
   - Dynamics properties should be defined at `.xacro` file  https://github.com/Field-Robotics-Lab/glider_hybrid_whoi/blob/824e8e0abaff1ac76fa144bf66ad01be39036f56/glider_hybrid_whoi_description/urdf/glider_hybrid_whoi_base_kinematics.xacro#L164-L186