### PR TITLE
Fix bugs with GPS update rate

### DIFF
--- a/glider_hybrid_whoi_ros_plugins/include/glider_hybrid_whoi_ros_plugins/UnderwaterGPSROSPlugin.hh
+++ b/glider_hybrid_whoi_ros_plugins/include/glider_hybrid_whoi_ros_plugins/UnderwaterGPSROSPlugin.hh
@@ -77,18 +77,18 @@ private:
   std::string fix_topic_;
   std::string velocity_topic_;
 
-  double update_rate_;
+  double update_rate_ = 0.25;
 
   double reference_latitude_;
   double reference_longitude_;
   double reference_heading_;
   double reference_altitude_;
   int espg_projection_;
-  double signal_delay_;
-  double signal_max_depth_;
+  double signal_delay_ = 10;
+  double signal_max_depth_ = 0;
   double signal_received_time_;
   double signal_confirm_time_;
-  bool onSurface_prev;
+  bool onSurface_prev = false;
 
   double radius_north_;
   double radius_east_;

--- a/glider_hybrid_whoi_ros_plugins/src/UnderwaterGPSROSPlugin.cc
+++ b/glider_hybrid_whoi_ros_plugins/src/UnderwaterGPSROSPlugin.cc
@@ -130,8 +130,8 @@ void GazeboRosGps::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   // if (_sdf->GetElement("referenceHeading")->GetValue()->Get(reference_heading_))
   //   reference_heading_ *= M_PI/180.0;
 
-  if (_sdf->HasElement("update_rate"))
-    _sdf->GetElement("update_rate")->GetValue()->Get(update_rate_);
+  if (_sdf->HasElement("updateRate"))
+    _sdf->GetElement("updateRate")->GetValue()->Get(update_rate_);
 
   if (_sdf->HasElement("espg_projection"))
     _sdf->GetElement("espg_projection")->GetValue()->Get(espg_projection_);
@@ -192,7 +192,7 @@ void GazeboRosGps::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   Reset();
 
   // connect Update function
-  updateTimer.setUpdateRate(1.0/update_rate_);
+  updateTimer.setUpdateRate(update_rate_);
   updateTimer.Load(world, _sdf);
   updateConnection = updateTimer.Connect(boost::bind(&GazeboRosGps::Update, this));
 }


### PR DESCRIPTION
The update rate of the GPS is specified in the xacro file using the updateRate
tag. This code was looking for update_rate.

Additionally, the update_rate_ var was never initialized, meaning that its
intial value (and only value due to the incorrect tag name) was whatever junk
was present on the heap when the class was instantiated. On my computer, when
running in Docker this was consistenly a value with a random mantissa but
exponent always around 10^-310. That is an absurdly slow update rate. However,
another bug is that updateTimer.setUpdateRate was called with a period instead
of rate. So this absurdly slow update rate got turned into an absurdly fast
update rate when configuring the timer.

When running outside of Docker, for whatever reason, I consistently got
update_rate_ initialized to zero. This turned signal_confirm_time_ into a NaN,
resulting in a GPS update never being sent.

While I was at it, I also initialized some more of the class variables.