### PR TITLE
free temporary coordinate transformations when we're done with them

### DIFF
--- a/glider_hybrid_whoi_ros_plugins/src/UnderwaterGPSROSPlugin.cc
+++ b/glider_hybrid_whoi_ros_plugins/src/UnderwaterGPSROSPlugin.cc
@@ -313,6 +313,7 @@ void GazeboRosGps::Update()
     double tLon = sNorthing;
     double tLat = sEasting;
     poCT->Transform(1, &tLat, &tLon);
+    delete poCT;
 
   #if (GAZEBO_MAJOR_VERSION >= 8)
     fix_.latitude = tLat;

--- a/kinematics_ros_plugins/src/KinematicsROSPlugin.cc
+++ b/kinematics_ros_plugins/src/KinematicsROSPlugin.cc
@@ -606,6 +606,7 @@ void KinematicsROSPlugin::ConveyModelState()
   double tLon = sNorthing;
   double tLat = sEasting;
   poCT->Transform(1, &tLat, &tLon);
+  delete poCT;
 
   // Construct UwGliderStatus msg
   frl_vehicle_msgs::UwGliderStatus status_msg;


### PR DESCRIPTION
Discovered with valgrind

Prior to this change, Gazebo leaked about 1 GB of RAM for every hour of
simulation time when sitting on the surface. After this change, I ran Gazebo
for 24 hours of simulation time and saw stable memory usage from the gzserver
process.

The next obvious source of memory troubles is going to be the map viewer. I
didn't see any easy way to clear out old popups in batch.